### PR TITLE
toNRGBA() altering the src image bug fix

### DIFF
--- a/stackblur.go
+++ b/stackblur.go
@@ -373,11 +373,6 @@ func Process(src image.Image, radius uint32) (*image.NRGBA, error) {
 // toNRGBA converts an image type to *image.NRGBA with min-point at (0, 0).
 func toNRGBA(img image.Image) *image.NRGBA {
 	srcBounds := img.Bounds()
-	if srcBounds.Min.X == 0 && srcBounds.Min.Y == 0 {
-		if src0, ok := img.(*image.NRGBA); ok {
-			return src0
-		}
-	}
 	srcMinX := srcBounds.Min.X
 	srcMinY := srcBounds.Min.Y
 


### PR DESCRIPTION
Hello

I have discovered a bug in the` toNRGBA()` function that causes side effects to the provided source image. When the bounds of the image start with [0, 0] (most cases), the original image is returned and later used to apply the blur, which is causing the altering of the original image. 

The solution was to remove the target bounds check and allow the function to fall back to the image.NRGBA copy creation.

Best regards,
Krzysztof Zoń