### PR TITLE
Provide custom destination image

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ The cli command supports a `-gif` flag, which if set as true it visualize the bl
 
 ## API
 
-The usage of the API is very simple: you need to expose an image file and a blur radius to the `Process` function. This will return the blurred version of the original image.
+The usage of the API is very simple: you need to expose an image file and a blur radius to the `Process` function. This will return the blurred version of the original image. Alternatively, you can use the `ProcessP` function to additionally provide the destination image pointer.
 
 ```Go
 stackblur.Process(src, blurRadius)
+stackblur.Process(src, dst, blurRadius)
 ```
 
 ## Results

--- a/doc.go
+++ b/doc.go
@@ -3,9 +3,10 @@ stackblur-go is a Go port of the Stackblur algorithm.
 
 Stackblur is a compromise between Gaussian blur and Box blur, but it creates much better looking blurs than Box blur and it is ~7x faster than Gaussian blur.
 
-The API is very simple and easy to integrate into any project. You only need to invoke the Process function which receive an image and a radius as parameters and returns the blurred version of the provided image.
+The API is very simple and easy to integrate into any project. You only need to invoke the Process function which receive an image and a radius as parameters and returns the blurred version of the provided image. There is also a ProcessP function which allows to provide the destination image pointer.
 
 	func Process(src image.Image, radius uint32) (*image.NRGBA, error)
+	func ProcessP(src image.Image, dst *image.NRGBA, radius uint32) error
 
 Below is a very simple example of how you can use this package.
 


### PR DESCRIPTION
Hello

I have implemented a `ProcessP` function that allows for providing an `image.NRGBA` destination pointer. This gives more control to the developer using this library when it comes to memory allocation.

One of my projects was using stackblur-go for processing a series of images and I saw a lot of allocations in my profiling result. This feature will allow for allocating an `image.NRGBA` and reuse it (its internal buffers) for multiple calls.

Best regards,
Krzysztof Zoń