### PR TITLE
Broken Github Actions due to deprecated actions/cache@v1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Cache-Go
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod              # Module download cache


### PR DESCRIPTION
Hello.

According to [this post](https://github.com/actions/cache/discussions/1510) the `actions/cache@v1` used in the Github Actions has been deprecated. The actions are failing because this dependency can not be resolved anymore. This pull-request aims to bump the version to to suggested `v4`.

Best regards,
Krzysztof Zoń