### PR TITLE
Silent failure on dst image type different than *image.NRGBA

### DIFF
--- a/stackblur.go
+++ b/stackblur.go
@@ -53,7 +53,7 @@ var shgTable = []uint32{
 	24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
 }
 
-// Process takes the source image and returns it's blurred version by applying the blur radius defined as parameter.
+// Process takes the source image and returns it's blurred version by applying the blur radius defined as parameter. The destination image must be a image.NRGBA.
 func Process(dst, src image.Image, radius uint32) error {
 	// Limit the maximum blur radius to 255 to avoid overflowing the multable.
 	if int(radius) >= len(mulTable) {
@@ -64,10 +64,12 @@ func Process(dst, src image.Image, radius uint32) error {
 		return errors.New("blur radius must be greater than 0")
 	}
 
-	if img, ok := dst.(*image.NRGBA); ok {
-		process(img, src, radius)
+	img, ok := dst.(*image.NRGBA)
+	if !ok {
+		return errors.New("the destination image must be image.NRGBA")
 	}
 
+	process(img, src, radius)
 	return nil
 }
 


### PR DESCRIPTION
Hello (it's me again)

I have found one bug that can be difficult to debug, due to its runtime nature and silent failure. Currently, there is no error handling for a case where the dst image is not a `*image.NRGBA`. A succesfull operation when passing `*image.NRGBA` as `dst` and a case when (for example) `*image.RGBA` is passed as `dst` can not be distinguished by the return value.

I have added a type validation for the `dst` image and a comment guiding the developer to provide an `image.Image` which is a `*image.NRGBA` internally. 

PoC:
```golang
func TestPoc(t *testing.T) {
	nrgbaImg := image.NewNRGBA(image.Rect(0, 0, 10, 10))
	rgbaImg := image.NewRGBA(image.Rect(0, 0, 10, 10))

	err := Process(rgbaImg, nrgbaImg, 10)

	if err == nil {
		t.Error("Rgba was used as the destination but no error was returned.")
	}
}
```

Best regards,
Krzysztof Zoń